### PR TITLE
Miscellaneous, small fixes/changes to "search-by" feature

### DIFF
--- a/frontend/src/components/dashboard/MuseumGallery.js
+++ b/frontend/src/components/dashboard/MuseumGallery.js
@@ -135,8 +135,9 @@ export default function MuseumGallery() {
                 onChange={handleChangeSearchField}
               >
                 <MenuItem value="all-fields">All Fields</MenuItem>
-                <MenuItem value="title">Title</MenuItem>
                 <MenuItem value="artist_title">Artist</MenuItem>
+                <MenuItem value="description">Description</MenuItem>
+                <MenuItem value="title">Title</MenuItem>
               </Select>
             </FormControl>
           </Container>

--- a/frontend/src/components/dashboard/MuseumGallery.js
+++ b/frontend/src/components/dashboard/MuseumGallery.js
@@ -51,16 +51,25 @@ const useStyles = makeStyles((theme) => ({
 export default function MuseumGallery() {
   const classes = useStyles();
 
+  /*
+   only set newQuery to be true when there is a change to the page number,
+   the "sort by" field, or when the search button is pressed
+  */
+  const [newQuery, setNewQuery] = React.useState(false);
+
   const [sortBy, setSortBy] = React.useState('relevance');
   const handleChangeSortBy = (event) => {
+    setNewQuery(true);
     setSortBy(event.target.value);
   };
   const [museumPage, setMuseumPage] = useState(1);
   const handleChangePage = (event, value) => {
+    setNewQuery(true);
     setMuseumPage(value);
   };
   const [searchQuery, setSearchQuery] = React.useState('');
   const handleChangeSearch = () => {
+    setNewQuery(true);
     setSearchQuery(document.getElementById('search-textfield').value);
     setMuseumPage(1);
   };
@@ -68,14 +77,19 @@ export default function MuseumGallery() {
   const handleChangeSearchField = (event) => {
     setSearchField(event.target.value);
   };
+
   const artworksMap = useSelector((state) => (state.museumArtworks.artworks));
   const artworks = Array.from(artworksMap);
   const dispatch = useDispatch();
-  const limit = 9;
+  const LIMIT = 9;
   useEffect(() => {
-    dispatch(fetchMuseumArtworks(
-        museumPage, limit, searchQuery, sortBy, searchField));
-  }, [dispatch, museumPage, searchQuery, sortBy, searchField]);
+    if (newQuery) {
+      dispatch(fetchMuseumArtworks(
+          museumPage, LIMIT, searchQuery, sortBy, searchField))
+          .then(setNewQuery(false));
+    }
+  }, [dispatch, newQuery]);
+
   let paginationNeeded = true;
   let results;
   if (artworks.length !== 0) {

--- a/frontend/src/components/dashboard/MuseumGallery.js
+++ b/frontend/src/components/dashboard/MuseumGallery.js
@@ -73,7 +73,7 @@ export default function MuseumGallery() {
     setSearchQuery(document.getElementById('search-textfield').value);
     setMuseumPage(1);
   };
-  const [searchField, setSearchField] = React.useState('title');
+  const [searchField, setSearchField] = React.useState('all-fields');
   const handleChangeSearchField = (event) => {
     setSearchField(event.target.value);
   };
@@ -134,6 +134,7 @@ export default function MuseumGallery() {
                 value={searchField}
                 onChange={handleChangeSearchField}
               >
+                <MenuItem value="all-fields">All Fields</MenuItem>
                 <MenuItem value="title">Title</MenuItem>
                 <MenuItem value="artist_title">Artist</MenuItem>
               </Select>

--- a/frontend/src/redux/museumArtworkActions.js
+++ b/frontend/src/redux/museumArtworkActions.js
@@ -153,6 +153,7 @@ function getMuseumArtworks(path, params, sortBy, searchField, search) {
     }
   }
   const API = apiUrl.toString();
+
   return fetch(API, {
     method: 'POST',
     headers: {
@@ -178,14 +179,26 @@ function artworksJsonToMap(artworks) {
 
 export function fetchMuseumArtworks(
     page, limit, searchQuery='', sortBy='relevance', searchField='') {
+  /*
+   if user wants to search by all fields, perform a simple query
+   instead of a complex query
+  */
+  let simpleQuery = '';
+  let searchFieldArgument = searchField;
+  if (searchField === 'all-fields') {
+    simpleQuery = searchQuery;
+    searchFieldArgument = '';
+  }
+
   return (dispatch) => {
     dispatch(fetchMuseumArtworksBegin());
     return getMuseumArtworks('artworks/search',
         new Map()
             .set('page', page)
-            .set('limit', limit),
+            .set('limit', limit)
+            .set('q', simpleQuery),
         sortBy,
-        searchField,
+        searchFieldArgument,
         searchQuery,
     )
         .then((artworks) => artworks.data)


### PR DESCRIPTION
![capture (7)](https://user-images.githubusercontent.com/42744910/88318178-f9dcec80-ccdf-11ea-9e9a-a77159ed132b.gif)

- Previously, a new api call was made anytime a user changed the "search by" field since it was included in the dependency array of the `useEffect` function but now this is fixed by including a state variable called `newQuery` in the `useEffect` function that is set to true when there is a change in the page number, a change in the "sort by" field, or when the user presses the search button
- "Search by" feature now has a default of "all fields." When a user searches using this search field, a simple query is made instead of making a complex query that uses Elasticsearch.  The complex query requires a field (such as artist or title) to "search by" which is why we don't include it here, since we want to "search by" all fields, not just one.
- Adds "description" as an option to search by.  If you guys think of any other fields that would be helpful to "search by," let me know!

Note: still working on CSS/styling of this feature (I incorporated the loading bar in another branch)